### PR TITLE
enhancements to lexer api

### DIFF
--- a/src/eonz/lexer/actions.lua
+++ b/src/eonz/lexer/actions.lua
@@ -19,18 +19,28 @@ function actions.pop_mode()
 	end
 end
 
+local function merge_impl(ctx, tok)
+	local t1 = ctx:tokens(-2)
+	local t2 = ctx:tokens(-1)
+
+	local result = Token.merge(t1, t2)
+	ctx:remove_token()
+	ctx:remove_token()
+	ctx:insert_token(result)
+end
+
+function actions.merge()
+	return merge_impl
+end
+
 function actions.merge_alike()
 	-- merges the top two tokens if they have the same id
 
 	return function (ctx, tok)
 		local t1 = ctx:tokens(-2)
 		local t2 = ctx:tokens(-1)
-
 		if t1:id() == t2:id() then
-			local result = Token.merge(t1, t2)
-			ctx:remove_token()
-			ctx:remove_token()
-			ctx:insert_token(result)
+			merge_impl(ctx, tok)
 		end
 	end
 end

--- a/src/eonz/lexer/context.lua
+++ b/src/eonz/lexer/context.lua
@@ -120,11 +120,13 @@ do
 		else
 			--print(production:id() .. " is valid in mode " .. self:mode())
 
+			--[[
 			for i, predicate in ipairs(production:predicates()) do
 				if not predicate(self, production) then
 					return nil
 				end
 			end
+			--]]
 
 			return production:match(self:source(), self:position(), self)
 		end
@@ -165,11 +167,13 @@ do
 
 		if not best then
 			return self:accept(Token {
-				error	= Token.ERROR_TOKEN_UNMATCHED,
-				start 	= self:position(),
-				stop 	= self:position() + 1,
-				source 	= self:source(),
-				context	= self
+				error		= Token.ERROR_TOKEN_UNMATCHED,
+				interval	= info.SourceInterval {
+					start 		= self:position(),
+					stop 		= self:position() + 1,
+					source 		= self:source(),
+				},
+				context		= self
 			})
 		end
 

--- a/src/eonz/lexer/production.lua
+++ b/src/eonz/lexer/production.lua
@@ -135,7 +135,7 @@ do
 				local stop 		= groups[#groups]
 				local captures		= table.slice(groups, 3, -2)
 
-				return Token {
+				local token = Token {
 					production 	= self,
 					text 		= token_text,
 
@@ -150,6 +150,21 @@ do
 					context		= ctx,
 					error		= self._error
 				}
+
+				for i, predicate in ipairs(self:predicates()) do
+					local token_response, rule_response = predicate(ctx, token)
+
+					if rule_response == false then
+						return nil
+					elseif not token_response then
+						token = nil
+						break
+					end
+				end
+
+				if token then
+					return token
+				end
 			end
 		end
 

--- a/src/eonz/lexer/token.lua
+++ b/src/eonz/lexer/token.lua
@@ -16,16 +16,17 @@ do
 			_text		= args.text,
 			_captures	= args.captures or {},
 			_ctx		= args.context,
-			_line_info	= args.line_info
+			_line_info	= args.line_info,
+			_data		= {}
 		}
 
 		return setmetatable(instance, Token)
 	end
 
 	function Token:merge(other)
-		if self:stop() ~= other:start() then
-			error("non-adjacent", 2)
-		end
+		--if self:stop() ~= other:start() then
+		--	error("non-adjacent", 2)
+		--end
 
 		return Token {
 			production 	= self:production(),
@@ -33,12 +34,13 @@ do
 			interval	= info.SourceInterval {
 				start 	= self:start(),
 				stop	= other:stop(),
-				source	= self:source()
+				source	= self:source(),
 			},
 
 			captures	= table.join(self:captures(), other:captures()),
 			alternative	= -1,
-			context		= self:context()
+			context		= self:context(),
+			data		= table.merge({}, self:data(), other:data())
 		}
 	end
 
@@ -52,8 +54,13 @@ do
 			},
 			captures	= {},
 			alternative	= -2,
-			context		= self:context()
+			context		= self:context(),
+			data		= table.copy(self:data())
 		}
+	end
+
+	function Token:data()
+		return self._data
 	end
 
 	function Token:context()

--- a/tests/eonz/json/test-parser-grammar.lua
+++ b/tests/eonz/json/test-parser-grammar.lua
@@ -90,7 +90,7 @@ tests['parser validation suite'] = function()
 
 
 		for i, token in ipairs(parser:stream():list()) do
-			print(token)
+			--print(token)
 		end
 
 		local result = invoke("in parser:json() for mock #" .. tostring(i) , parser.json, parser)


### PR DESCRIPTION
predicates are now handled per-alternative in the production itself. 
Predicates can either invalidate the token for a single alternative, or 
proactively invalidate ALL alternatives for the production at the 
current source position.

Merging tokens no long requires that tokens be adjacent, as this causes 
issues when tokens are skipped.